### PR TITLE
Fix: Linux clipboard fallback skips xsel when xclip is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Clipboard fallback on Linux now correctly tries `xsel` when `xclip` is not
+  installed. Previously both commands shared a single `try/except`, so a
+  `FileNotFoundError` from `xclip` aborted the loop before `xsel` was ever
+  attempted.
+
 ---
 
 ## [0.7.0] — 2026-03-19

--- a/snip/utils/clipboard.py
+++ b/snip/utils/clipboard.py
@@ -20,21 +20,34 @@ def copy_to_clipboard(text: str) -> bool:
         print(f"snip: pyperclip error — {e}", file=sys.stderr)
 
     # Fallback: platform native commands
-    try:
-        if sys.platform == "darwin":
+    if sys.platform == "darwin":
+        try:
             subprocess.run(["pbcopy"], input=text.encode(), check=True)
             return True
-        if sys.platform == "win32":
-            subprocess.run(
-                ["clip"], input=text.encode("utf-16"), check=True
-            )
+        except Exception as e:
+            print(f"snip: clipboard error — {e}", file=sys.stderr)
+    elif sys.platform == "win32":
+        try:
+            subprocess.run(["clip"], input=text.encode("utf-16"), check=True)
             return True
-        # Linux – try xclip or xsel
-        for cmd in (["xclip", "-selection", "clipboard"], ["xsel", "--clipboard", "--input"]):
-            result = subprocess.run(cmd, input=text.encode(), capture_output=True)
-            if result.returncode == 0:
-                return True
-    except Exception as e:
-        print(f"snip: clipboard error — {e}", file=sys.stderr)
+        except Exception as e:
+            print(f"snip: clipboard error — {e}", file=sys.stderr)
+    else:
+        # Linux – try xclip then xsel.  Each command is wrapped in its own
+        # try/except so that a missing tool (FileNotFoundError) causes us to
+        # fall through to the next candidate rather than aborting the loop.
+        for cmd in (
+            ["xclip", "-selection", "clipboard"],
+            ["xsel", "--clipboard", "--input"],
+        ):
+            try:
+                result = subprocess.run(cmd, input=text.encode(), capture_output=True)
+                if result.returncode == 0:
+                    return True
+            except FileNotFoundError:
+                continue
+            except Exception as e:
+                print(f"snip: clipboard error — {e}", file=sys.stderr)
+                break
 
     return False

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -26,3 +26,33 @@ class TestCopyToClipboard:
                 with patch("sys.platform", "linux"):
                     result = copy_to_clipboard("hello")
         assert result is False
+    def test_falls_back_to_xsel_when_xclip_missing(self):
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "xclip":
+                raise FileNotFoundError
+            return MagicMock(returncode=0)
+
+        with patch.dict("sys.modules", {"pyperclip": None}):
+            with patch("subprocess.run", side_effect=fake_run):
+                with patch("sys.platform", "linux"):
+                    result = copy_to_clipboard("hello")
+        assert result is True
+
+    def test_uses_xclip_when_xsel_missing(self):
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "xclip":
+                return MagicMock(returncode=0)
+            raise FileNotFoundError
+
+        with patch.dict("sys.modules", {"pyperclip": None}):
+            with patch("subprocess.run", side_effect=fake_run):
+                with patch("sys.platform", "linux"):
+                    result = copy_to_clipboard("hello")
+        assert result is True
+
+    def test_returns_false_when_neither_tool_installed(self):
+        with patch.dict("sys.modules", {"pyperclip": None}):
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                with patch("sys.platform", "linux"):
+                    result = copy_to_clipboard("hello")
+        assert result is False


### PR DESCRIPTION
## What does this PR do?

On Linux, `copy_to_clipboard()` tried `xclip` and `xsel` as fallbacks inside a single shared `try/except` block. If `xclip` wasn't installed, the `FileNotFoundError` it raised escaped the loop and was caught by the outer handler — meaning `xsel` was never tried. Users with `xsel` but not `xclip` (common on Debian/Ubuntu) would silently fail to copy even though a working tool was present.

The fix wraps each command in its own `try/except` inside the loop, so a missing tool just `continue`s to the next candidate. The macOS and Windows branches are also given their own `try/except` blocks for the same reason.

Three regression tests are added covering: xsel succeeding when xclip is absent, xclip succeeding when xsel is absent, and `False` returned cleanly when neither tool is installed.

## Related issue

No related issue.

## Checklist
- [x] Tests pass (`make test`)
- [x] New behaviour is covered by tests (if applicable)
- [x] CHANGELOG.md updated under `[Unreleased]`

```md
## [Unreleased]

### Fixed
- Clipboard fallback on Linux now correctly tries `xsel` when `xclip` is not
  installed. Previously both commands shared a single `try/except`, so a
  `FileNotFoundError` from `xclip` aborted the loop before `xsel` was ever
  attempted.
```